### PR TITLE
Fix syntax highlighting

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,6 +1,6 @@
 CodeMirror.defineSimpleMode("gorilla", {
   start: [
-    { regex: /"(?:[^\\]|\\.)*?"/s, token: "string" },
+    { regex: /".*?"/s, token: "string" },
     {
       regex: /(func)(\s+)([\w$]+)/,
       token: ["keyword", null, "variable"],

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,6 +1,6 @@
 CodeMirror.defineSimpleMode("gorilla", {
   start: [
-    { regex: /"(?:[^\\]|\\.)*?(?:"|$)/, token: "string" },
+    { regex: /"(?:[^\\]|\\.)*?"/s, token: "string" },
     {
       regex: /(func)(\s+)([\w$]+)/,
       token: ["keyword", null, "variable"],
@@ -15,19 +15,19 @@ CodeMirror.defineSimpleMode("gorilla", {
     },
     { regex: /true|false|null/, token: "atom" },
     {
-      regex: /0x[a-f\d]+|[-+]?(?:\.\d+|\d+\.?\d*)(?:e[-+]?\d+)?/i,
+      regex: /[-+]?(?:\d+)/i,
       token: "number",
     },
     { regex: /#.*/, token: "comment" },
     { regex: /[-+\/*=<>!]+/, token: "operator" },
     { regex: /[\{\[\(]/, indent: true },
     { regex: /[\}\]\)]/, dedent: true },
-    { regex: /([\w$]+)(\()/, token: ["variable", null] },
-    { regex: /[\w$]+/, token: "variable-2" },
+    { regex: /([\w]+)(\()/, token: ["variable", null] },
+    { regex: /[\w]+/, token: "variable-2" },
   ],
   meta: {
     dontIndentStates: ["comment"],
-    lineComment: "//",
+    lineComment: "#",
   },
 });
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,6 +1,6 @@
 CodeMirror.defineSimpleMode("gorilla", {
   start: [
-    { regex: /".*?"/s, token: "string" },
+    { regex: /"[\s\S]*?"/, token: "string" },
     {
       regex: /(func)(\s+)([\w$]+)/,
       token: ["keyword", null, "variable"],


### PR DESCRIPTION
Sadly, multiline strings are not parsed properly by CodeMirror due to the fact that CodeMirror parses one line at a time instead the entire textarea at once. There are complicated ways to fix that, but it would not be worth wasting time to try to fix that.

You probably want to merge as "Compress and Merge" or whatever has the same meaning as compressing these 3 commits into 1 before committing to master, or you can just do normal merging, whatever you want to do.